### PR TITLE
fix: changed deprecated Kirby\Toolkit\Query

### DIFF
--- a/lib/pagetable.php
+++ b/lib/pagetable.php
@@ -1,6 +1,6 @@
 <?php
 
-use Kirby\Toolkit\Query;
+use Kirby\Query\Query;
 use Kirby\Toolkit\Str;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
@@ -89,13 +89,13 @@ $options = A::merge($options, [
                 }
             } else {
                 // added to support query
-                $q = new Query($this->query, [
+                $q = new Query($this->query);
+                $pages = $q->resolve([
                     'site' => site(),
                     'page' => $this->model(),
                     'pages' => site()->pages(),
                     'kirby' => kirby()
                 ]);
-                $pages = $q->result();
             }
 
             // loop for the best performance


### PR DESCRIPTION
3.8.2 Use `Kirby\Query\Query` instead // TODO: Remove in 3.10.0

See:
- https://github.com/sylvainjule/kirby-pagetable/issues/88